### PR TITLE
[G2M] devops - Added portunus integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN yum -y update && yum -y updateinfo && yum install -y \
     && sh ./get_helm.sh \
     && yum upgrade openssl \
     && pip3 install print-env \
-    && yum clean all \
+    && yum clean all
 ENV PATH="/root/.tfenv/bin:$PATH"
 RUN mkdir /work
 WORKDIR /work

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM amazon/aws-cli
 RUN yum -y update && yum install -y \
     git \
+    jq \
     unzip \
     curl \
     wget \
@@ -15,7 +16,8 @@ RUN yum -y update && yum install -y \
     && curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
     && chmod 700 get_helm.sh \
     && sh ./get_helm.sh \
-    && yum clean all
+    && yum clean all \
+    && pip3 install print-env
 ENV PATH="/root/.tfenv/bin:$PATH"
 RUN mkdir /work
 WORKDIR /work

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM amazon/aws-cli
-RUN yum -y update && yum install -y \
+RUN yum -y update && yum -y updateinfo && yum install -y \
     git \
     jq \
     unzip \
@@ -16,8 +16,9 @@ RUN yum -y update && yum install -y \
     && curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 \
     && chmod 700 get_helm.sh \
     && sh ./get_helm.sh \
+    && yum upgrade openssl \
+    && pip3 install print-env \
     && yum clean all \
-    && pip3 install print-env
 ENV PATH="/root/.tfenv/bin:$PATH"
 RUN mkdir /work
 WORKDIR /work

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN yum -y update && yum -y updateinfo && yum install -y \
     && chmod 700 get_helm.sh \
     && sh ./get_helm.sh \
     && yum upgrade openssl \
+    && pip3 install urllib3==1.26.7 \
     && pip3 install print-env \
     && yum clean all
 ENV PATH="/root/.tfenv/bin:$PATH"

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,8 @@
 ```bash
 git clone https://github.com/ashishjullia/docker-dev-awscli.git && cd ansible/single-liner
 ```
+
+### Note: This is only required if you are not using portunus
 #### Create and ".env" file to pass the secrets
 ```bash
 TF_VERSION=
@@ -31,6 +33,14 @@ vim ~/.bashrc
 
 ```bash
 alias dev="docker run -it --rm -v $PWD:/work -w /work --env-file=.env --entrypoint /script.sh ashishjullia19/terraform-aws-cli"
+```
+
+With portunus integration:
+For `PORTUNUS_TOKEN` make sure to grab this from portunus ui `portunus.ashishjullia.com` and you'll get the token in format:
+`PORTUNUS_TOKEN=<TOKEN>/<PORTUNUS_TEAM>/<PORTUNUS_PROJECT>/<PORTUNUS_STAGE>`
+By default you can set the token on your host system under PORTUNUS_TOKEN until `<TOKEN>/<PORTUNUS_TEAM>/<PORTUNUS_PROJECT>`, the other parts of the token can be populated inside the container via `.env` file to keep things more dynamic (as once created the `PORTUNUS_TEAM` value remains the same for a user until and unless they are part of other teams as well)
+```bash
+alias dev="docker run -it --rm -v $PWD:/work -w /work --env-file=.env -e PORTUNUS_TOKEN=$PORTUNUS_TOKEN --entrypoint /script.sh ashishjullia19/terraform-aws-cli"
 ```
 
 ```bash

--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ alias dev="docker run -it --rm -v $PWD:/work -w /work --env-file=.env --entrypoi
 With portunus integration:
 For `PORTUNUS_TOKEN` make sure to grab this from portunus ui `portunus.ashishjullia.com` and you'll get the token in format:
 `PORTUNUS_TOKEN=<TOKEN>/<PORTUNUS_TEAM>/<PORTUNUS_PROJECT>/<PORTUNUS_STAGE>`. Then `<PORTUNUS_TEAM>` will not be same as you'll see in ui, it will be a random value.
-By default, you can set the token on your host system under PORTUNUS_TOKEN until `<TOKEN>/<PORTUNUS_TEAM>/<PORTUNUS_PROJECT>`, the other parts of the token can be populated inside the container via `.env` file to keep things more dynamic (as once created the `PORTUNUS_TEAM` value remains the same for a user until and unless they are part of other teams as well)
+By default, you can set the token on your host system under PORTUNUS_TOKEN until `<TOKEN>/<PORTUNUS_TEAM>`, the other parts of the token can be populated inside the container via `.env` file to keep things more dynamic (as once created the `PORTUNUS_TEAM` value remains the same for a user until and unless they are part of other teams as well)
 ```bash
 alias dev="docker run -it --rm -v $PWD:/work -w /work --env-file=.env -e PORTUNUS_TOKEN=$PORTUNUS_TOKEN --entrypoint /script.sh ashishjullia19/terraform-aws-cli"
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ alias dev="docker run -it --rm -v $PWD:/work -w /work --env-file=.env --entrypoi
 With portunus integration:
 For `PORTUNUS_TOKEN` make sure to grab this from portunus ui `portunus.ashishjullia.com` and you'll get the token in format:
 `PORTUNUS_TOKEN=<TOKEN>/<PORTUNUS_TEAM>/<PORTUNUS_PROJECT>/<PORTUNUS_STAGE>`. Then `<PORTUNUS_TEAM>` will not be same as you'll see in ui, it will be a random value.
-By default, you can set the token on your host system under PORTUNUS_TOKEN until `<TOKEN>/<PORTUNUS_TEAM>`, the other parts of the token can be populated inside the container via `.env` file to keep things more dynamic (as once created the `PORTUNUS_TEAM` value remains the same for a user until and unless they are part of other teams as well)
+By default, you can set the token on your host system under PORTUNUS_TOKEN until `<TOKEN>/<PORTUNUS_TEAM>`, the other parts of the token can be populated inside the container via `.env` file to keep things more dynamic (as once created the `PORTUNUS_TEAM` value remains the same for a user until and unless they are part of other teams as well) OR you can also pass `<PORTUNUS_PROJECT>` `<PORTUNUS_STAGE>` via docker command itself just do `-e <PORTUNUS_PROJECT>=<PORTUNUS_PROJECT>` `-e <PORTUNUS_STAGE>=<PORTUNUS_PROJECT>` 
 ```bash
 alias dev="docker run -it --rm -v $PWD:/work -w /work --env-file=.env -e PORTUNUS_TOKEN=$PORTUNUS_TOKEN --entrypoint /script.sh ashishjullia19/terraform-aws-cli"
 ```

--- a/Readme.md
+++ b/Readme.md
@@ -37,8 +37,8 @@ alias dev="docker run -it --rm -v $PWD:/work -w /work --env-file=.env --entrypoi
 
 With portunus integration:
 For `PORTUNUS_TOKEN` make sure to grab this from portunus ui `portunus.ashishjullia.com` and you'll get the token in format:
-`PORTUNUS_TOKEN=<TOKEN>/<PORTUNUS_TEAM>/<PORTUNUS_PROJECT>/<PORTUNUS_STAGE>`
-By default you can set the token on your host system under PORTUNUS_TOKEN until `<TOKEN>/<PORTUNUS_TEAM>/<PORTUNUS_PROJECT>`, the other parts of the token can be populated inside the container via `.env` file to keep things more dynamic (as once created the `PORTUNUS_TEAM` value remains the same for a user until and unless they are part of other teams as well)
+`PORTUNUS_TOKEN=<TOKEN>/<PORTUNUS_TEAM>/<PORTUNUS_PROJECT>/<PORTUNUS_STAGE>`. Then `<PORTUNUS_TEAM>` will not be same as you'll see in ui, it will be a random value.
+By default, you can set the token on your host system under PORTUNUS_TOKEN until `<TOKEN>/<PORTUNUS_TEAM>/<PORTUNUS_PROJECT>`, the other parts of the token can be populated inside the container via `.env` file to keep things more dynamic (as once created the `PORTUNUS_TEAM` value remains the same for a user until and unless they are part of other teams as well)
 ```bash
 alias dev="docker run -it --rm -v $PWD:/work -w /work --env-file=.env -e PORTUNUS_TOKEN=$PORTUNUS_TOKEN --entrypoint /script.sh ashishjullia19/terraform-aws-cli"
 ```

--- a/script.sh
+++ b/script.sh
@@ -1,49 +1,47 @@
 #!/usr/bin/env bash
-# This shebang is more portable and will find bash wherever it's located in the system.
 
-# Set script to exit on error or if an undefined variable is used
+# Exit on error or if an undefined variable is used
 set -eu
 
-# Function to print an error message and exit the script
-# Arguments:
-#   1. Error message (required)
-#   2. Exit status code (optional; default is 1)
+# Check for dependencies
+for cmd in jq tfenv aws curl; do
+    command -v "$cmd" >/dev/null 2>&1 || error_exit "$cmd is required but not installed."
+done
+
+# Print error and exit
 function error_exit {
-    # Print the error message to stderr
     echo "$1" >&2
-    # Exit the script with the provided status code, or 1 if none was provided
     exit "${2:-1}"
 }
 
-while IFS="=" read -r key value; do export "$key=$(printf %b "$value")"; done < <(print-env --api https://portunusapiprod.ashishjullia.com/env --format json | jq -r 'to_entries[] | "\(.key)=\(.value)"')
-
-# Check if the necessary environment variables are set, and exit with an error message if they're not
+# Ensure PORTUNUS_TOKEN is set
 [[ -z "${PORTUNUS_TOKEN}" ]] && error_exit "PORTUNUS_TOKEN is not set."
 
-# If TF_VERSION is set, use that. Otherwise, default to the latest version
+# Fetch and export environment variables from a given API
+while IFS="=" read -r key value; do 
+    export "$key=$(printf %b "$value")"
+done < <(print-env --api "https://portunusapiprod.ashishjullia.com/env" --format json | jq -r 'to_entries[] | "\(.key)=\(.value)"')
+
+# Install specified Terraform version or default to the latest
 TF_VERSION="${TF_VERSION:-latest}"
 echo "Installing Terraform version: ${TF_VERSION}"
-tfenv install $TF_VERSION || error_exit "Failed to install Terraform version: ${TF_VERSION}"
-tfenv use $TF_VERSION || error_exit "Failed to switch to Terraform version: ${TF_VERSION}"
+tfenv install "$TF_VERSION" || error_exit "Failed to install Terraform version: ${TF_VERSION}"
+tfenv use "$TF_VERSION" || error_exit "Failed to switch to Terraform version: ${TF_VERSION}"
 
-# Configure AWS
+# Configure AWS with specified credentials
 echo "Configuring AWS with region: ${AWS_REGION}"
-# Set the AWS region, and exit with an error message if the command fails
-aws configure set region $AWS_REGION || error_exit "Failed to set AWS region: ${AWS_REGION}"
-# Set the AWS access key, and exit with an error message if the command fails
-aws configure set aws_access_key_id $AWS_ACCESS_KEY_ID || error_exit "Failed to set AWS access key."
-# Set the AWS secret access key, and exit with an error message if the command fails
-aws configure set aws_secret_access_key $AWS_SECRET_ACCESS_KEY || error_exit "Failed to set AWS secret access key."
+aws configure set region "$AWS_REGION" || error_exit "Failed to set AWS region: ${AWS_REGION}"
+aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" || error_exit "Failed to set AWS access key."
+aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" || error_exit "Failed to set AWS secret access key."
 
-# Update the kubeconfig for the specified cluster if NAME_OF_CLUSTER is set
+# Update kubeconfig if cluster name is provided
 if [[ -n "${NAME_OF_CLUSTER}" ]]; then
-    aws eks update-kubeconfig --region $AWS_REGION --name $NAME_OF_CLUSTER || error_exit "Failed to update kubeconfig for cluster: ${NAME_OF_CLUSTER}"
+    aws eks update-kubeconfig --region "$AWS_REGION" --name "$NAME_OF_CLUSTER" || error_exit "Failed to update kubeconfig for cluster: ${NAME_OF_CLUSTER}"
 fi
 
-# If the FLUX_VERSION environment variable is set, install that version of Flux
+# Install specified Flux version if provided
 if [[ -n "$FLUX_VERSION" ]]; then
     echo "Installing Flux version: ${FLUX_VERSION}"
-    # Download and run the Flux installation script, and exit with an error message if the command fails
     curl -s https://fluxcd.io/install.sh | bash || error_exit "Failed to install Flux version: ${FLUX_VERSION}"
 fi
 

--- a/script.sh
+++ b/script.sh
@@ -15,10 +15,10 @@ function error_exit {
     exit "${2:-1}"
 }
 
+while IFS="=" read -r key value; do export "$key=$(printf %b "$value")"; done < <(print-env --api https://portunusapiprod.ashishjullia.com/env --format json | jq -r 'to_entries[] | "\(.key)=\(.value)"')
+
 # Check if the necessary environment variables are set, and exit with an error message if they're not
-[[ -z "${AWS_REGION}" ]] && error_exit "AWS_REGION is not set."
-[[ -z "${AWS_ACCESS_KEY_ID}" ]] && error_exit "AWS_ACCESS_KEY_ID is not set."
-[[ -z "${AWS_SECRET_ACCESS_KEY}" ]] && error_exit "AWS_SECRET_ACCESS_KEY is not set."
+[[ -z "${PORTUNUS_TOKEN}" ]] && error_exit "PORTUNUS_TOKEN is not set."
 
 # If TF_VERSION is set, use that. Otherwise, default to the latest version
 TF_VERSION="${TF_VERSION:-latest}"

--- a/script.sh
+++ b/script.sh
@@ -14,6 +14,8 @@ for cmd in jq tfenv aws curl print-env; do
     command -v "$cmd" >/dev/null 2>&1 || error_exit "$cmd is required but not installed."
 done
 
+PORTUNUS_TOKEN="${PORTUNUS_TOKEN}${PORTUNUS_PROJECT}${PORTUNUS_STAGE}"
+
 # Ensure PORTUNUS_TOKEN is set
 [[ -z "${PORTUNUS_TOKEN}" ]] && error_exit "PORTUNUS_TOKEN is not set."
 

--- a/script.sh
+++ b/script.sh
@@ -14,7 +14,7 @@ for cmd in jq tfenv aws curl print-env; do
     command -v "$cmd" >/dev/null 2>&1 || error_exit "$cmd is required but not installed."
 done
 
-PORTUNUS_TOKEN="${PORTUNUS_TOKEN}${PORTUNUS_PROJECT}${PORTUNUS_STAGE}"
+PORTUNUS_TOKEN="${PORTUNUS_TOKEN}/${PORTUNUS_PROJECT}/${PORTUNUS_STAGE}"
 
 # Ensure PORTUNUS_TOKEN is set
 [[ -z "${PORTUNUS_TOKEN}" ]] && error_exit "PORTUNUS_TOKEN is not set."

--- a/script.sh
+++ b/script.sh
@@ -1,18 +1,18 @@
 #!/usr/bin/env bash
 
-# Exit on error or if an undefined variable is used
-set -eu
+# Exit on any error
+set -e
 
-# Check for dependencies
-for cmd in jq tfenv aws curl; do
-    command -v "$cmd" >/dev/null 2>&1 || error_exit "$cmd is required but not installed."
-done
-
-# Print error and exit
+# Function to print an error and exit
 function error_exit {
     echo "$1" >&2
     exit "${2:-1}"
 }
+
+# Check for dependencies
+for cmd in jq tfenv aws curl print-env; do
+    command -v "$cmd" >/dev/null 2>&1 || error_exit "$cmd is required but not installed."
+done
 
 # Ensure PORTUNUS_TOKEN is set
 [[ -z "${PORTUNUS_TOKEN}" ]] && error_exit "PORTUNUS_TOKEN is not set."
@@ -22,19 +22,20 @@ while IFS="=" read -r key value; do
     export "$key=$(printf %b "$value")"
 done < <(print-env --api "https://portunusapiprod.ashishjullia.com/env" --format json | jq -r 'to_entries[] | "\(.key)=\(.value)"')
 
-# Install specified Terraform version or default to the latest
+# Install the specified Terraform version or default to the latest
 TF_VERSION="${TF_VERSION:-latest}"
 echo "Installing Terraform version: ${TF_VERSION}"
 tfenv install "$TF_VERSION" || error_exit "Failed to install Terraform version: ${TF_VERSION}"
 tfenv use "$TF_VERSION" || error_exit "Failed to switch to Terraform version: ${TF_VERSION}"
 
-# Configure AWS with specified credentials
+# Configure AWS with the specified or default credentials
+AWS_REGION="${AWS_REGION:-us-west-1}"  # Consider adding a default if appropriate
 echo "Configuring AWS with region: ${AWS_REGION}"
 aws configure set region "$AWS_REGION" || error_exit "Failed to set AWS region: ${AWS_REGION}"
 aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID" || error_exit "Failed to set AWS access key."
 aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY" || error_exit "Failed to set AWS secret access key."
 
-# Update kubeconfig if cluster name is provided
+# Update kubeconfig if a cluster name is provided
 if [[ -n "${NAME_OF_CLUSTER}" ]]; then
     aws eks update-kubeconfig --region "$AWS_REGION" --name "$NAME_OF_CLUSTER" || error_exit "Failed to update kubeconfig for cluster: ${NAME_OF_CLUSTER}"
 fi
@@ -45,4 +46,5 @@ if [[ -n "$FLUX_VERSION" ]]; then
     curl -s https://fluxcd.io/install.sh | bash || error_exit "Failed to install Flux version: ${FLUX_VERSION}"
 fi
 
+# Exit to a bash prompt
 /bin/bash


### PR DESCRIPTION
Changes/Fixes:
- Added portunus integration [portunus.ashishjullia.com](https://portunus.ashishjullia.com) to directly source env key:value pairs from it instead of passing the values from a `.env` file.
- Does it affect the current `.env` functionality? - `NO`, you can still source your env key:value pairs via `.env` file as well.